### PR TITLE
Generate rust docs

### DIFF
--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -1,6 +1,14 @@
 name: Backend CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/**'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/**'
 
 defaults:
   run:

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,36 @@
+
+# Derived from https://github.com/rust-analyzer/rust-analyzer/blob/master/.github/workflows/rustdoc.yaml
+name: Backend Docs
+on:
+  push:
+   branches:
+   - master
+
+defaults:
+  run:
+    working-directory: backend
+
+jobs:
+  rustdoc:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+        components: rustfmt, rust-src
+    - uses: Swatinem/rust-cache@v1
+    - name: Generate Docs
+      run: cargo doc --all --no-deps
+    - name: Deploy Docs
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_branch: gh-pages
+        publish_dir: ./backend/target/doc
+        destination_dir: ./docs
+        keep_files: true
+

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -3,8 +3,11 @@
 name: Backend Docs
 on:
   push:
-   branches:
-   - master
+    paths:
+      - 'backend/**'
+      - '.github/**'
+    branches:
+      - master
 
 defaults:
   run:

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -1,6 +1,14 @@
 name: Frontend CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'frontend/**'
+      - '.github/**'
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/**'
 
 defaults:
   run:


### PR DESCRIPTION
Generates and pushes our rust docs to the [github pages website](https://itjustworkstm.github.io/EiffelVis/) I already setup the website to include a link to the docs.

[direct link](https://itjustworkstm.github.io/EiffelVis/docs/eiffelvis/index.html)

while I was there I setup conditional ci runs for the frontend / backend to be a bit nicer to githubs servers