### PR TITLE
chunked_graph: reverse link direction

### DIFF
--- a/backend/crates/eiffelvis_core/src/graph_storage/mod.rs
+++ b/backend/crates/eiffelvis_core/src/graph_storage/mod.rs
@@ -1,3 +1,3 @@
-mod chunked_storage;
+pub mod chunked_storage;
 
 pub use chunked_storage::Graph as ChunkedGraph;


### PR DESCRIPTION
As the title says, we've discussed this in the original RFC and I believe its still a good idea.

Along with the change I implemented an extra test and a crude function in EiffelVisApp to show how this is useful.

did require some extra utility methods for this, so those are added as well.

before:

ev1 <- ev2 <- ev3

after:

ev1 -> ev2 -> ev3
