### PR TITLE
backgen/gen+core: blanket support for meta tags / source #35

### DIFF
--- a/backend/crates/eiffelvis_core/src/types.rs
+++ b/backend/crates/eiffelvis_core/src/types.rs
@@ -11,6 +11,18 @@ pub struct BaseMeta {
     pub event_type: String,
     pub version: String,
     pub time: u64,
+    pub tags: Option<Vec<String>>,
+    pub source: Option<MetaSource>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct MetaSource {
+    #[serde(rename = "domainId")] // Doesn't follow convention, so rename
+    pub domain_id: Option<String>,
+    pub host: Option<String>,
+    pub name: Option<String>,
+    pub serializer: Option<String>,
+    pub uri: Option<String>,
 }
 
 #[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]

--- a/backend/crates/eiffelvis_gen/src/base_event.rs
+++ b/backend/crates/eiffelvis_gen/src/base_event.rs
@@ -11,6 +11,18 @@ pub struct BaseMeta {
     pub event_type: String,
     pub version: String,
     pub time: u64,
+    pub tags: Option<Vec<String>>,
+    pub source: Option<MetaSource>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct MetaSource {
+    #[serde(rename = "domainId")] // Doesn't follow convention, so rename
+    pub domain_id: Option<String>,
+    pub host: Option<String>,
+    pub name: Option<String>,
+    pub serializer: Option<String>,
+    pub uri: Option<String>,
 }
 
 #[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Seeing a bit of code dupe here, but I dont want to decide yet if we want to share these definitions.

Should probably look into randomizing this data.

fixes #35