### PR TITLE
frontend/net: initial networking api

### DIFF
--- a/frontend/src/helpers/dataParser.ts
+++ b/frontend/src/helpers/dataParser.ts
@@ -1,7 +1,7 @@
 import { GraphData } from '@antv/g6/lib/types'
-import IEvent from '../interfaces/ApiData'
+import { Event } from '../interfaces/ApiData'
 
-export default (data: IEvent[]) => {
+export default (data: Event[]) => {
   const G6Data: GraphData = { nodes: [], edges: [] }
   data.forEach(({ id, time, edges }) => {
     G6Data.nodes!.push({

--- a/frontend/src/helpers/useEiffelNet.ts
+++ b/frontend/src/helpers/useEiffelNet.ts
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react'
+import { Collection, Filter, Query, ServerMessage } from '../interfaces/ApiData'
+import useWebsocket from './useWebSocket'
+
+const useEiffelNet = (onEvents: any, onReset: any) => {
+  const [awaitingResponse, setAwaitingResponse] = useState<Boolean>(false)
+  const [awaitingResponseCount, setAwaitingResponseCount] = useState<number>(0)
+
+  const [isConnected, setIsConnected] = useState<Boolean>(false)
+
+  const [messageQueue, setMessageQueue] = useState<ServerMessage[]>([])
+
+  const onMessage = (event: ServerMessage) => {
+    setMessageQueue([...messageQueue, event])
+  }
+
+  useEffect(() => {
+    messageQueue.forEach((event: ServerMessage) => {
+      console.log('event ', event)
+      if (Array.isArray(event)) {
+        onEvents(event)
+      } else {
+        if (awaitingResponseCount === 0) {
+          console.log('Unexpected mode change!')
+        } else {
+          setAwaitingResponseCount(awaitingResponseCount - 1)
+        }
+
+        if (event.error != null) {
+          console.log('failed to switch modes! ', event)
+        } else {
+          console.log('ok')
+          onReset()
+        }
+      }
+    })
+    if (messageQueue.length > 0) {
+      setMessageQueue([])
+    }
+  }, [messageQueue])
+
+  const onConnect = () => {
+    setIsConnected(true)
+  }
+
+  const { reconnecting, sendMessage } = useWebsocket(onMessage, onConnect)
+
+  useEffect(() => {
+    if (reconnecting) {
+      setIsConnected(false)
+    }
+  }, [reconnecting])
+
+  const [filters, setFilters] = useState<Filter[]>([])
+  const [collection, setCollection] = useState<Collection>(null)
+
+  useEffect(() => {
+    if (collection == null) {
+      console.log('no collection specified, not querying')
+    } else if (!isConnected) {
+      console.log('web socket not connected')
+    } else {
+      const msg = <Query>{ filters, collection }
+      console.log('sending out new query ', msg)
+      if (sendMessage(msg)) {
+        setAwaitingResponseCount(awaitingResponseCount + 1)
+      } else {
+        console.log('failed to send message, bad things may happen')
+      }
+    }
+  }, [filters, collection, isConnected])
+
+  useEffect(() => {
+    setAwaitingResponse(awaitingResponseCount > 0)
+  }, [awaitingResponseCount])
+
+  return {
+    awaitingResponse,
+    setFilters,
+    setCollection,
+  }
+}
+
+export default useEiffelNet

--- a/frontend/src/helpers/useTweakPane.ts
+++ b/frontend/src/helpers/useTweakPane.ts
@@ -4,25 +4,47 @@ import { TweakCb } from '../interfaces/types'
 
 const useTweakPane = (cb: TweakCb): void => {
   const [paneData, setPaneData] = useState<any>({
-    type: 'All',
+    collection_type: 'Forward',
+    filter_type: 'None',
     id: '',
+    begin: 0,
+    end: -1,
+    name: '',
   })
 
   useEffect(() => {
     const pane = new Pane({ title: 'Events', expanded: true })
-    pane.addInput(paneData, 'type', {
-      label: 'Type',
-      options: { All: 'All', WithRoot: 'WithRoot' },
+    pane.addInput(paneData, 'collection_type', {
+      label: 'Collection',
+      options: { Forward: 'Forward', AsRoots: 'AsRoots' },
+    })
+    pane.addInput(paneData, 'filter_type', {
+      label: 'Filter',
+      options: { None: 'None', Time: 'Time', Ids: 'Ids', Type: 'Type' },
     })
     pane.addSeparator()
+    pane.addInput(paneData, 'begin', {
+      label: 'begin',
+      step: 1,
+    })
+
+    pane.addInput(paneData, 'end', {
+      label: 'end',
+      step: 1,
+    })
+
     pane.addInput(paneData, 'id', {
       label: 'node id',
+    })
+
+    pane.addInput(paneData, 'name', {
+      label: 'type name',
       step: 1,
     })
 
     pane
       .addButton({
-        title: 'New Nodes',
+        title: 'Submit',
       })
       .on('click', () => cb(pane.exportPreset()))
 

--- a/frontend/src/helpers/useWebSocket.ts
+++ b/frontend/src/helpers/useWebSocket.ts
@@ -29,7 +29,13 @@ const useWebsocket = (onMsg: OnMessage, onConnect?: OnConnect) => {
   }, [reconnecting])
 
   const sendMessage = (obj: object) => {
-    if (socket.current) socket.current.send(JSON.stringify(obj))
+    if (socket.current) {
+      if (socket.current!.readyState === 1) {
+        socket.current.send(JSON.stringify(obj))
+        return true
+      }
+    }
+    return false
   }
 
   return {

--- a/frontend/src/interfaces/ApiData.d.ts
+++ b/frontend/src/interfaces/ApiData.d.ts
@@ -1,5 +1,47 @@
-export default interface IEvent {
-  id: string
+// Interally tagged type for types that are part of a enum
+type TypeTag<K, T> = K & { type: T }
+
+export type Uuid = string
+
+export interface Event {
+  id: Uuid
   time: number
-  edges: Array<string>
+  edges: Array<Uuid>
 }
+
+interface _Time {
+  begin?: number
+  end?: number
+}
+export type Time = TypeTag<_Time, 'Time'>
+
+interface _Type {
+  name: string
+}
+export type Type = TypeTag<_Type, 'Type'>
+
+interface _Ids {
+  ids: Array<Uuid>
+}
+export type Ids = TypeTag<_Ids, 'Ids'>
+
+export type Forward = TypeTag<_Forward, 'Forward'>
+interface _Forward {}
+
+export type AsRoots = TypeTag<_AsRoots, 'AsRoots'>
+interface _AsRoots {}
+
+export type Filter = null | Time | Type | Ids
+export type Collection = null | Forward | AsRoots
+
+export interface Query {
+  filters: Filter[]
+  collection: Collection
+}
+
+export interface QueryRes {
+  repl: string
+  error?: string
+}
+
+export type ServerMessage = QueryRes | Event[]

--- a/frontend/src/interfaces/types.ts
+++ b/frontend/src/interfaces/types.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-unused-vars */
-import IEvent from './ApiData'
+import Event, { ServerMessage } from './ApiData'
 
-export type TweakCb = (obj: object) => void
-export type OnMessage = (obj: IEvent[]) => void
+export type TweakCb = (obj: any) => void
+export type OnMessage = (obj: ServerMessage) => void
 export type OnConnect = () => void
 export type SendMessage = (obj: object) => void
 export type getNodesWithRootFun = (id: string) => void


### PR DESCRIPTION
Implements the new networking api implemented in #40 

I'm not really a fan of the tweakpane, so I did not put much effort in making it fully flashed out, but all (currently backend support) filter types are supported in some way or another.