### PR TITLE
Switch entire stack to use unix millis instead of seconds

### DIFF
--- a/backend/crates/eiffelvis_core/src/domain/types.rs
+++ b/backend/crates/eiffelvis_core/src/domain/types.rs
@@ -10,7 +10,7 @@ pub struct BaseMeta {
     #[serde(rename = "type")]
     pub event_type: String,
     pub version: String,
-    pub time: u64,
+    pub time: u128,
 }
 
 #[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
@@ -30,7 +30,7 @@ pub struct BaseEvent {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct LeanEvent {
     pub id: Uuid,
-    pub time: u64,
+    pub time: String,
     pub edges: Vec<Uuid>,
 }
 
@@ -38,7 +38,7 @@ impl From<&BaseEvent> for LeanEvent {
     fn from(ev: &BaseEvent) -> Self {
         Self {
             id: ev.meta.id,
-            time: ev.meta.time,
+            time: format!("{}", ev.meta.time),
             edges: ev.links.iter().map(|link| link.target).collect(),
         }
     }

--- a/backend/crates/eiffelvis_core/src/domain/user_queries.rs
+++ b/backend/crates/eiffelvis_core/src/domain/user_queries.rs
@@ -23,8 +23,8 @@ pub enum Filter {
     None,
     /// Open ended range of time
     Time {
-        begin: Option<u64>,
-        end: Option<u64>,
+        begin: Option<u128>,
+        end: Option<u128>,
     },
     /// Event Type
     Type { name: String },

--- a/backend/crates/eiffelvis_core/src/graph_storage/chunked_storage.rs
+++ b/backend/crates/eiffelvis_core/src/graph_storage/chunked_storage.rs
@@ -97,7 +97,7 @@ impl<K: graph::Key, N, E> ChunkedGraph<K, N, E> {
 
     /// Translates relative index (starting from tail) to absolute
     fn to_absolute(&self, index: ChunkedIndex) -> usize {
-        (index.0 * self.max_elements) + index.1 - self.tail * self.max_elements
+        (index.0 * self.max_elements) + index.1 - (self.tail * self.max_elements)
     }
 
     pub fn chunks(&self) -> usize {

--- a/backend/crates/eiffelvis_gen/src/base_event.rs
+++ b/backend/crates/eiffelvis_gen/src/base_event.rs
@@ -10,7 +10,7 @@ pub struct BaseMeta {
     #[serde(rename = "type")]
     pub event_type: String,
     pub version: String,
-    pub time: u64,
+    pub time: u128,
 }
 
 #[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]

--- a/backend/crates/eiffelvis_gen/src/generator.rs
+++ b/backend/crates/eiffelvis_gen/src/generator.rs
@@ -244,11 +244,10 @@ impl Iterator for Iter<'_> {
         event.meta.event_type = meta_event.name().to_string();
         event.meta.id = Uuid::from_bytes(self.rng.get_mut().gen());
 
-        // TODO: allow specifying a starting time and a time delay between events
         event.meta.time = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .as_secs();
+            .as_millis();
 
         event.links = generated_links;
 

--- a/frontend/src/components/TooltipCard.tsx
+++ b/frontend/src/components/TooltipCard.tsx
@@ -5,12 +5,13 @@ import { getNodesWithRootFun } from '../interfaces/types'
 
 interface IProps {
   id: string
+  time: bigint
   x: number
   y: number
   getNodesWithRoot: getNodesWithRootFun
 }
 
-const CustomCard: React.FC<IProps> = ({ id, x, y, getNodesWithRoot }) => (
+const CustomCard: React.FC<IProps> = ({ id, time, x, y, getNodesWithRoot }) => (
   <Card
     className={styles.cardContainer}
     bg="dark"
@@ -20,6 +21,7 @@ const CustomCard: React.FC<IProps> = ({ id, x, y, getNodesWithRoot }) => (
     <Card.Header>Event Information</Card.Header>
     <Card.Body className="d-grid">
       <p>Event ID: {id}</p>
+      <p>Event Time: {time.toString()}</p>
       <Button onClick={() => getNodesWithRoot(id)} variant="outline-light">
         Nodes With This Root
       </Button>

--- a/frontend/src/helpers/useEiffelNet.ts
+++ b/frontend/src/helpers/useEiffelNet.ts
@@ -8,14 +8,20 @@ const useEiffelNet = (onEvents: any, onReset: any) => {
 
   const [isConnected, setIsConnected] = useState<Boolean>(false)
 
-  const [messageQueue, setMessageQueue] = useState<ServerMessage[]>([])
+  const [messageQueue, setMessageQueue] = useState<string[]>([])
 
-  const onMessage = (event: ServerMessage) => {
+  const onMessage = (event: string) => {
     setMessageQueue([...messageQueue, event])
   }
 
   useEffect(() => {
-    messageQueue.forEach((event: ServerMessage) => {
+    messageQueue.forEach((eventBuf: string) => {
+      const event = JSON.parse(eventBuf, (key, value) => {
+        if (key === "time") {
+          return BigInt(value)
+        } 
+        return value
+      }) as ServerMessage
       console.log('event ', event)
       if (Array.isArray(event)) {
         onEvents(event)
@@ -62,7 +68,7 @@ const useEiffelNet = (onEvents: any, onReset: any) => {
     } else {
       const msg = <Query>{ filters, collection }
       console.log('sending out new query ', msg)
-      if (sendMessage(msg)) {
+      if (sendMessage(JSON.stringify(msg))) {
         setAwaitingResponseCount(awaitingResponseCount + 1)
       } else {
         console.log('failed to send message, bad things may happen')

--- a/frontend/src/helpers/useWebSocket.ts
+++ b/frontend/src/helpers/useWebSocket.ts
@@ -12,7 +12,7 @@ const useWebsocket = (onMsg: OnMessage, onConnect?: OnConnect) => {
       if (onConnect) onConnect()
     }
 
-    socket.current.onmessage = (e) => onMsg(JSON.parse(e.data))
+    socket.current.onmessage = (e) => onMsg(e.data)
 
     socket.current.onclose = () => {
       if (socket.current) {
@@ -28,10 +28,10 @@ const useWebsocket = (onMsg: OnMessage, onConnect?: OnConnect) => {
     }
   }, [reconnecting])
 
-  const sendMessage = (obj: object) => {
+  const sendMessage = (obj: string) => {
     if (socket.current) {
       if (socket.current!.readyState === 1) {
-        socket.current.send(JSON.stringify(obj))
+        socket.current.send(obj)
         return true
       }
     }

--- a/frontend/src/interfaces/ApiData.d.ts
+++ b/frontend/src/interfaces/ApiData.d.ts
@@ -5,7 +5,7 @@ export type Uuid = string
 
 export interface Event {
   id: Uuid
-  time: number
+  time: bigint
   edges: Array<Uuid>
 }
 

--- a/frontend/src/interfaces/types.ts
+++ b/frontend/src/interfaces/types.ts
@@ -2,7 +2,7 @@
 import Event, { ServerMessage } from './ApiData'
 
 export type TweakCb = (obj: any) => void
-export type OnMessage = (obj: ServerMessage) => void
+export type OnMessage = (obj: string) => void
 export type OnConnect = () => void
 export type SendMessage = (obj: object) => void
 export type getNodesWithRootFun = (id: string) => void


### PR DESCRIPTION
So apparently we made the assumption that unix time on eiffel vocabulary actually used unix time, but instead it actually uses a special flavor that represents milliseconds instead.

millis cannot be represented by 64bits hence:
On the backend we switch everything that has to do with time to use `u128` and make LeanEvent use String to represent time.
On the frontend we switch everything that has to do with time to use BigInt and deserialize the string time to BigInt manually.

this probably has a small performance penalty as we now have to allocate a whole string whenever we send something to the frontend. So would be good to investigate how javascript deals with large JSON numbers.