### PR TITLE
backend/core: implement and add a `range` iterator to the Graph trait

### DIFF
--- a/backend/crates/eiffelvis_core/src/domain/user_queries.rs
+++ b/backend/crates/eiffelvis_core/src/domain/user_queries.rs
@@ -76,8 +76,7 @@ impl<I> TrackedQuery<I> {
         R: From<&'a BaseEvent> + 'static,
         I: Idx,
     {
-        let fresh = self.inner.handle(graph);
-        let iter = fresh.filter(|node| {
+        let iter = self.inner.handle(graph).filter(|node| {
             self.filters.iter().all(|filter| match filter {
                 Filter::None => true,
                 Filter::Time { begin, end } => {

--- a/backend/crates/eiffelvis_core/src/graph.rs
+++ b/backend/crates/eiffelvis_core/src/graph.rs
@@ -92,14 +92,33 @@ where
     fn target(&self) -> Self::Idx;
 }
 
-// TODO: slightly cursed
-pub trait HasNodeIter<'a, T, _Outlives = &'a Self> {
-    type NodeIterType: Iterator<Item = T>;
+pub trait HasNodeIter<'a, _Outlives = &'a Self> {
+    type Item;
+    type NodeIterType: Iterator<Item = Self::Item>;
 }
-pub type NodeIterType<'a, This> = <This as HasNodeIter<'a, NodeType<'a, This>>>::NodeIterType;
+pub type NodeIterType<'a, This> = <This as HasNodeIter<'a>>::NodeIterType;
 
-pub trait ItemIter: for<'a> HasNodeIter<'a, NodeType<'a, Self>> + for<'a> HasNode<'a> {
+pub trait HasNodeRangeIter<'a, _Outlives = &'a Self> {
+    type Item;
+    type NodeRangeIterType: Iterator<Item = Self::Item>;
+}
+pub type NodeRangeIterType<'a, This> = <This as HasNodeRangeIter<'a>>::NodeRangeIterType;
+
+pub trait ItemIter:
+    for<'a> HasNodeIter<'a, Item = NodeType<'a, Self>>
+    + for<'a> HasNodeRangeIter<'a, Item = NodeType<'a, Self>>
+    + for<'a> HasNode<'a>
+{
+    /// Returns a ranged iterator over the nodes of this graph in order of insertion
     fn items(&self) -> NodeIterType<'_, Self>;
+
+    /// Returns a ranged iterator over the nodes of this graph
+    /// Note: end is exlusive
+    fn range(
+        &self,
+        begin: Option<Self::Idx>,
+        end: Option<Self::Idx>,
+    ) -> NodeRangeIterType<'_, Self>;
 }
 
 pub trait Indexable<T>: for<'a> HasNode<'a> {

--- a/backend/crates/eiffelvis_core/src/tracked_query.rs
+++ b/backend/crates/eiffelvis_core/src/tracked_query.rs
@@ -20,17 +20,9 @@ impl<I> TrackedNodes<I> {
         G: Graph<Idx = I>,
         I: Idx,
     {
-        // TODO: reverse NodeIterator?
-        let mut iter = graph.items();
-
-        // TODO: consider building this into the Graph trait..
-        if let Some(cursor) = self.cursor {
-            iter.by_ref().take_while(|el| el.id() != cursor).count();
-        }
-
         TrackedNodesIter {
+            inner: graph.range(self.cursor, None),
             owner: self,
-            inner: iter,
         }
     }
 }
@@ -43,7 +35,7 @@ impl<I> Default for TrackedNodes<I> {
 
 pub struct TrackedNodesIter<'a, I, G: ItemIter> {
     owner: &'a mut TrackedNodes<I>,
-    inner: NodeIterType<'a, G>,
+    inner: NodeRangeIterType<'a, G>,
 }
 
 impl<'a, I, G> Iterator for TrackedNodesIter<'a, I, G>
@@ -86,6 +78,7 @@ impl<I> TrackedSubGraphs<I> {
             .map(|i| graph.index(*i))
             .roots_for_graph(graph);
 
+        // This is unavoidable as the entire graph needs to collected before we can reason about it
         if let Some(cursor) = self.cursor {
             iter.by_ref().take_while(|el| el.id() != cursor).count();
         }


### PR DESCRIPTION
Reworks node iterators a bit to more easily allow for ranged iteration.

Haven't tested this properly yet :)

In theory this saves a lot of work in tracked nodes, but we still have to spin our chunk iterator since IndexMap doesn't expose a similar range api