### PR TITLE
backend/query: filter out empty filters

### DIFF
--- a/backend/crates/eiffelvis_core/src/domain/user_queries.rs
+++ b/backend/crates/eiffelvis_core/src/domain/user_queries.rs
@@ -146,7 +146,7 @@ impl<I> TrackedQuery<I> {
             if self.event_filters.is_empty() {
                 true
             } else {
-                self.event_filters.iter().any(|filters| {
+                self.event_filters.iter().filter(|v| !v.is_empty()).any(|filters| {
                     filters.iter().all(|filter| match &filter.pred {
                         EventFilter::Type { names: ref name } => name.iter().any(|name| &node.data().meta.event_type == name),
                         EventFilter::Id { ids } =>


### PR DESCRIPTION
certain individuals send sloppy queries to the backend with an empty specific filter, before it defaulted to true now it defaults to false to avoid unexpected behavior

