### PR TITLE
Event sender modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ TODO
 1. start your rabbitmq server 
   `rabbitmq server` or `brew services start rabbitmq` if you are using homebrew on mac. 
 2. If not activated, activate the management pluggin by running `rabbitmq-plugins enable rabbitmq_management`
-2. go to `http://localhost:15672`to enter the rabbitMQ management page. (default credentials are username & password: `guest`)
-3. go to the queue panel and create a new queue. The queue has to use the same name as the one you are going to use with the backend (default `hello`)
-4 go to the exchange panel and select `amq.fanout`in the list.
-5. Click on `Bindings`and add the binding of this exchange to the queue using the same name as step 3. 
-6. go into `EiffelVis/backend/tools/event_sender`and run the command `cargo run -- -r <any_routing_key>` (you can also add other options, run to `cargo run -- --help`for more info)
-7. go into `EiffelVis/backend`and run `cargo run`
-8. go into `EiffelVis/frontend`and run `npm run dev`
-9. open your browser to `localhost:8080`and you should have nodes coming and being displayed on the graph. 
+3. go to `http://localhost:15672`to enter the rabbitMQ management page. (default credentials are username & password: `guest`)
+4. go to the queue panel and create a new queue. The queue has to use the same name as the one you are going to use with the backend (default `hello`)
+5 go to the exchange panel and select `amq.fanout`in the list.
+6. Click on `Bindings`and add the binding of this exchange to the queue using the same name as step 3. 
+7. go into `EiffelVis/backend/tools/event_sender`and run the command `cargo run -- -r <any_routing_key>` (you can also add other options, run to `cargo run -- --help`for more info)
+8. go into `EiffelVis/backend`and run `cargo run`
+9. go into `EiffelVis/frontend`and run `npm run dev`
+10. open your browser to `localhost:8080`and you should have nodes coming and being displayed on the graph. 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ TODO
 
 1. start your rabbitmq server 
   `rabbitmq server` or `brew services start rabbitmq` if you are using homebrew on mac. 
+2. If not activated, activate the management pluggin by running `rabbitmq-plugins enable rabbitmq_management`
 2. go to `http://localhost:15672`to enter the rabbitMQ management page. (default credentials are username & password: `guest`)
 3. go to the queue panel and create a new queue. The queue has to use the same name as the one you are going to use with the backend (default `hello`)
 4 go to the exchange panel and select `amq.fanout`in the list.

--- a/README.md
+++ b/README.md
@@ -74,3 +74,20 @@ To contribute to this repository, please see the [contribution guidelines](./CON
 If you would like to read more about the algorithm used by EiffelVis, please see the [algorithm concept](./frontend/README.md#layout-algorithm).
 
 Copyright © 2022, EiffelVis. EiffelVis is a product by ItJustWorks™.
+
+# Testing
+
+TODO
+
+# Event Sender and testing instructions (for default rabbitmq configuration)
+
+1. start your rabbitmq server 
+  `rabbitmq server` or `brew services start rabbitmq` if you are using homebrew on mac. 
+2. go to `http://localhost:15672`to enter the rabbitMQ management page. (default credentials are username & password: `guest`)
+3. go to the queue panel and create a new queue. The queue has to use the same name as the one you are going to use with the backend (default `hello`)
+4 go to the exchange panel and select `amq.fanout`in the list.
+5. Click on `Bindings`and add the binding of this exchange to the queue using the same name as step 3. 
+6. go into `EiffelVis/backend/tools/event_sender`and run the command `cargo run -- -r <any_routing_key>` (you can also add other options, run to `cargo run -- --help`for more info)
+7. go into `EiffelVis/backend`and run `cargo run`
+8. go into `EiffelVis/frontend`and run `npm run dev`
+9. open your browser to `localhost:8000`and you should have nodes coming and being displayed on the graph. 

--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ TODO
 6. go into `EiffelVis/backend/tools/event_sender`and run the command `cargo run -- -r <any_routing_key>` (you can also add other options, run to `cargo run -- --help`for more info)
 7. go into `EiffelVis/backend`and run `cargo run`
 8. go into `EiffelVis/frontend`and run `npm run dev`
-9. open your browser to `localhost:8000`and you should have nodes coming and being displayed on the graph. 
+9. open your browser to `localhost:8080`and you should have nodes coming and being displayed on the graph. 

--- a/backend/crates/eiffelvis_gen/src/eiffel_vocabulary.rs
+++ b/backend/crates/eiffelvis_gen/src/eiffel_vocabulary.rs
@@ -5,8 +5,29 @@ use rand::Rng;
 pub struct EiffelVocabulary;
 
 const EVENT_TYPES: [&str; 23] = [
-    "ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS", "TCT",
-    "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS",
+    "EiffelActivityStartedEvent",
+    "EiffelActivityTriggeredEvent",
+    "EiffelActivityCanceledEvent",
+    "EiffelActivityFinishedEvent",
+    "EiffelArtifactCreatedEvent",
+    "EiffelArtifactPublishedEvent",
+    "EiffelArtifactReusedEvent",
+    "EiffelTestCaseStartedEvent",
+    "EiffelTestCaseTriggeredEvent",
+    "EiffelTestCaseCanceledEvent",
+    "EiffelTestCaseFinishedEvent",
+    "EiffelTestSuiteStartedEvent",
+    "EiffelTestExecutionRecipeCollectionCreatedEvent",
+    "EiffelTestSuiteFinishedEvent",
+    "EiffelAnnouncementPublishedEvent",
+    "EiffelCompositionDefinedEvent",
+    "EiffelConfidenceLevelModifiedEvent",
+    "EiffelEnvironmentDefinedEvent",
+    "EiffelFlowContextDefinedEvent",
+    "EiffelIssueDefinedEvent",
+    "EiffelIssueVerifiedEvent",
+    "EiffelSourceChangeCreatedEvent",
+    "EiffelSourceChangeSubmittedEvent",
 ];
 
 impl From<EiffelVocabulary> for EventSet {

--- a/backend/crates/eiffelvis_gen/src/eiffel_vocabulary.rs
+++ b/backend/crates/eiffelvis_gen/src/eiffel_vocabulary.rs
@@ -1,0 +1,42 @@
+use crate::event_set::{Event, EventSet, Link};
+
+use rand::Rng;
+
+pub struct EiffelVocabulary;
+
+const EVENT_TYPES: [&str; 23] = [
+    "ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS", "TCT",
+    "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS",
+];
+
+impl From<EiffelVocabulary> for EventSet {
+    fn from(_: EiffelVocabulary) -> Self {
+        let mut builder = EventSet::build();
+
+        for eventtype in EVENT_TYPES {
+            // Initialize and create the event variable
+            let mut event = Event::new(eventtype.to_string(), "1.0.0");
+
+            // Create the random number generate for the links
+            let _randomrange = rand::thread_rng().gen_range(1..3);
+
+            // Loop and add the links to the event
+            for linknumber in 0.._randomrange {
+                event = event.with_link(format!("Link{linknumber}"));
+            }
+
+            builder = builder.add_event(event);
+        }
+
+        builder
+            .add_link(Link::new("Link0", true))
+            .add_link(Link::new("Link1", true))
+            .add_event(
+                Event::new("Event", "1.0.0")
+                    .with_link("Link0")
+                    .with_link("Link1"),
+            )
+            .build()
+            .expect("This should work")
+    }
+}

--- a/backend/crates/eiffelvis_gen/src/generator.rs
+++ b/backend/crates/eiffelvis_gen/src/generator.rs
@@ -79,7 +79,7 @@ impl Default for EventGenerator {
         Self {
             inner: Inner {
                 event_set: EventSet::default(),
-                max_links: 5,
+                max_links: 10,
                 history_max: 100,
             },
             seed: rand::random::<usize>().into(),
@@ -223,11 +223,11 @@ impl Iterator for Iter<'_> {
             "TCT", "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS"];
             
         // Random number generator used to select a random index of the above
-        fn random_num() -> usize{
+        fn random_num(min: usize, max: usize) -> usize{
             let mut rng = rand::thread_rng();
-            return rng.gen_range(0..22);
+            return rng.gen_range(min..max);
         }
-
+        
         // Randomly pick a link and select an event for it until we reach our target or we exhaust possible events
         while let Some((i, (link, _))) = {
             let ret = generatable_events
@@ -236,9 +236,10 @@ impl Iterator for Iter<'_> {
                 .choose(&mut *self.rng.borrow_mut());
             ret
         } {
+            
             if generated_links.len() >= target_amount {
                 break;
-            }
+            }         
 
             let exhausted = if let Some(bl) = select_event(*link) {
                 generated_links.push(bl);
@@ -252,7 +253,7 @@ impl Iterator for Iter<'_> {
             }
         }
 
-        event.meta.event_type = event_types[random_num()].to_string();
+        event.meta.event_type = event_types[random_num(0, 22)].to_string();
         event.meta.id = Uuid::from_bytes(self.rng.get_mut().gen());
 
         event.meta.time = SystemTime::now()

--- a/backend/crates/eiffelvis_gen/src/generator.rs
+++ b/backend/crates/eiffelvis_gen/src/generator.rs
@@ -217,17 +217,18 @@ impl Iterator for Iter<'_> {
             .borrow_mut()
             .gen_range(0..self.inner.max_links - generated_links.len());
 
+        // List of possible eiffel events
+        let event_types: [&str; 23] = [
+            "ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS",
+            "TCT", "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS",
+        ];
 
-        // List of possible eiffel events 
-        let event_types: [&str; 23] = ["ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS",
-            "TCT", "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS"];
-            
         // Random number generator used to select a random index of the above
-        fn random_num(min: usize, max: usize) -> usize{
+        fn random_num(min: usize, max: usize) -> usize {
             let mut rng = rand::thread_rng();
-            return rng.gen_range(min..max);
+            rng.gen_range(min..max)
         }
-        
+
         // Randomly pick a link and select an event for it until we reach our target or we exhaust possible events
         while let Some((i, (link, _))) = {
             let ret = generatable_events
@@ -236,10 +237,9 @@ impl Iterator for Iter<'_> {
                 .choose(&mut *self.rng.borrow_mut());
             ret
         } {
-            
             if generated_links.len() >= target_amount {
                 break;
-            }         
+            }
 
             let exhausted = if let Some(bl) = select_event(*link) {
                 generated_links.push(bl);

--- a/backend/crates/eiffelvis_gen/src/generator.rs
+++ b/backend/crates/eiffelvis_gen/src/generator.rs
@@ -217,6 +217,17 @@ impl Iterator for Iter<'_> {
             .borrow_mut()
             .gen_range(0..self.inner.max_links - generated_links.len());
 
+
+        // List of possible eiffel events 
+        let event_types: [&str; 23] = ["ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS",
+            "TCT", "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS"];
+            
+        // Random number generator used to select a random index of the above
+        fn random_num() -> usize{
+            let mut rng = rand::thread_rng();
+            return rng.gen_range(0..22);
+        }
+
         // Randomly pick a link and select an event for it until we reach our target or we exhaust possible events
         while let Some((i, (link, _))) = {
             let ret = generatable_events
@@ -241,7 +252,7 @@ impl Iterator for Iter<'_> {
             }
         }
 
-        event.meta.event_type = meta_event.name().to_string();
+        event.meta.event_type = event_types[random_num()].to_string();
         event.meta.id = Uuid::from_bytes(self.rng.get_mut().gen());
 
         event.meta.time = SystemTime::now()

--- a/backend/crates/eiffelvis_gen/src/generator.rs
+++ b/backend/crates/eiffelvis_gen/src/generator.rs
@@ -217,18 +217,6 @@ impl Iterator for Iter<'_> {
             .borrow_mut()
             .gen_range(0..self.inner.max_links - generated_links.len());
 
-        // List of possible eiffel events
-        let event_types: [&str; 23] = [
-            "ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS",
-            "TCT", "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS",
-        ];
-
-        // Random number generator used to select a random index of the above
-        fn random_num(min: usize, max: usize) -> usize {
-            let mut rng = rand::thread_rng();
-            rng.gen_range(min..max)
-        }
-
         // Randomly pick a link and select an event for it until we reach our target or we exhaust possible events
         while let Some((i, (link, _))) = {
             let ret = generatable_events
@@ -253,7 +241,7 @@ impl Iterator for Iter<'_> {
             }
         }
 
-        event.meta.event_type = event_types[random_num(0, 22)].to_string();
+        event.meta.event_type = meta_event.name().to_string();
         event.meta.id = Uuid::from_bytes(self.rng.get_mut().gen());
 
         event.meta.time = SystemTime::now()

--- a/backend/crates/eiffelvis_gen/src/lib.rs
+++ b/backend/crates/eiffelvis_gen/src/lib.rs
@@ -40,6 +40,9 @@ pub mod event_set;
 /// Generator that stamps out events.
 pub mod generator;
 
+/// Vocabulary used to create eiffel events.
+pub mod eiffel_vocabulary;
+
 #[doc(hidden)]
 pub(crate) mod base_event;
 

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -19,11 +19,11 @@ struct Cli {
     // When setting these values, keep in mind that the generator process will stop at whichever value is reached first (between the count and total duration).
     // The defaut settings on these variables represent roughly 30,000 events sent per hour.
 
-    // Total amount of events to be sent (note: multiplied with the `burst` option)
+    /// Total amount of events to be sent (note: multiplied with the `burst` option)
     #[clap(default_value = "30000", short, long)]
     count: usize,
 
-    // Total duration to run the event generator
+    /// Total duration to run the event generator
     #[clap(default_value = "3600000", short, long)]
     total_duration: usize,
 
@@ -36,7 +36,6 @@ struct Cli {
     exchange: String,
 
     /// Routing key used for ampq connections
-
     #[clap(short, long)]
     routing_key: String,
 
@@ -56,6 +55,7 @@ struct Cli {
     #[clap(default_value = "1", short, long)]
     burst: usize,
 
+    /// Option to replay from a file (Input a path to a JSON file)
     #[clap(long)]
     replay: Option<String>,
 }

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -104,22 +104,13 @@ async fn app() -> anyhow::Result<()> {
         Box::new(gen.iter())
     };
 
-<<<<<<< HEAD
-    let target = cli.count * cli.burst;
+    let target = cli.count;
 
     println!(
         "\nSending out a maximum of {} events, over a maximum duration of {} seconds. \nProcess will stop at whichever comes first. \nEvents sent at random intervals between {}-{}ms. \n",
-        target, (cli.total_duration / 1000), cli.min_latency, cli.latency_max
-=======
-    let target = cli.count;
-    let sleep_duration = Duration::from_millis(cli.latency as u64);
-
-    println!(
-        "Sending out ~{} events, {} events every {}ms interval",
         target * cli.burst,
-        cli.burst,
-        cli.latency
->>>>>>> 65aed53 (Backend/gen:BUG-FIX sent count: #27)
+        (cli.total_duration / 1000), cli.min_latency,
+        cli.latency_max
     );
 
     let mut sent = 0;

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -103,18 +103,25 @@ async fn app() -> anyhow::Result<()> {
 
     let mut builder = EventSet::build();
 
-    for i in EVENT_TYPES {
-        builder = builder.add_event(
-            Event::new(i.to_string(), "1.0.0")
-                .with_link("Link0")
-                .with_link("Link1"),
-        );
+    for eventtype in EVENT_TYPES {
+        // Initialize and create the event variable
+        let mut event = Event::new(eventtype.to_string(), "1.0.0");
+
+        // Create the random number generate for the links
+        let _randomrange = rand::thread_rng().gen_range(1..3);
+
+        // Loop and add the links to the event
+        for linknumber in 0.._randomrange {
+            event = event.with_link(format!("Link{linknumber}"));
+        }
+
+        builder = builder.add_event(event);
     }
 
     let gen = EventGenerator::new(
         cli.seed.unwrap_or_else(|| thread_rng().gen::<usize>()),
-        6,
-        8,
+        16,
+        18,
         builder
             .add_link(Link::new("Link0", true))
             .add_link(Link::new("Link1", true))

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -104,11 +104,22 @@ async fn app() -> anyhow::Result<()> {
         Box::new(gen.iter())
     };
 
+<<<<<<< HEAD
     let target = cli.count * cli.burst;
 
     println!(
         "\nSending out a maximum of {} events, over a maximum duration of {} seconds. \nProcess will stop at whichever comes first. \nEvents sent at random intervals between {}-{}ms. \n",
         target, (cli.total_duration / 1000), cli.min_latency, cli.latency_max
+=======
+    let target = cli.count;
+    let sleep_duration = Duration::from_millis(cli.latency as u64);
+
+    println!(
+        "Sending out ~{} events, {} events every {}ms interval",
+        target * cli.burst,
+        cli.burst,
+        cli.latency
+>>>>>>> 65aed53 (Backend/gen:BUG-FIX sent count: #27)
     );
 
     let mut sent = 0;

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -86,6 +86,15 @@ async fn app() -> anyhow::Result<()> {
 
     let channel_a = conn.create_channel().await?;
 
+    channel_a
+        .queue_declare(
+            "hello",
+            QueueDeclareOptions::default(),
+            FieldTable::default(),
+        )
+        .await?;
+
+        // println!(?queue, "Declared queue");
     println!("Connected to broker.");
     
     let gen = EventGenerator::new(

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -18,7 +18,6 @@ struct Cli {
     // NOTE: The number of events along with the total duration, min lacency and latency max is to be used for stress testing.
     // When setting these values, keep in mind that the generator process will stop at whichever value is reached first (between the count and total duration).
     // The defaut settings on these variables represent roughly 30,000 events sent per hour.
-
     /// Total amount of events to be sent (note: multiplied with the `burst` option)
     #[clap(default_value = "30000", short, long)]
     count: usize,

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -99,8 +99,8 @@ async fn app() -> anyhow::Result<()> {
     
     let gen = EventGenerator::new(
         cli.seed.unwrap_or_else(|| thread_rng().gen::<usize>()),
-        4,
-        8,
+        10,
+        11,
         EventSet::build()
             .add_link(Link::new("Link0", true))
             .add_link(Link::new("Link1", true))

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -16,11 +16,29 @@ use clap::Parser;
 use rand::{thread_rng, Rng};
 
 const EVENT_TYPES: [&str; 23] = [
-    "EiffelActivityStartedEvent", "EiffelActivityTriggeredEvent", "EiffelActivityCanceledEvent", "EiffelActivityFinishedEvent", "EiffelArtifactCreatedEvent", 
-    "EiffelArtifactPublishedEvent", "EiffelArtifactReusedEvent", "EiffelTestCaseStartedEvent", "EiffelTestCaseTriggeredEvent", "EiffelTestCaseCanceledEvent", 
-    "EiffelTestCaseFinishedEvent", "EiffelTestSuiteStartedEvent", "EiffelTestExecutionRecipeCollectionCreatedEvent", "EiffelTestSuiteFinishedEvent", 
-    "EiffelAnnouncementPublishedEvent", "EiffelCompositionDefinedEvent", "EiffelConfidenceLevelModifiedEvent", "EiffelEnvironmentDefinedEvent", 
-    "EiffelFlowContextDefinedEvent", "EiffelIssueDefinedEvent", "EiffelIssueVerifiedEvent", "EiffelSourceChangeCreatedEvent", "EiffelSourceChangeSubmittedEvent",
+    "EiffelActivityStartedEvent",
+    "EiffelActivityTriggeredEvent",
+    "EiffelActivityCanceledEvent",
+    "EiffelActivityFinishedEvent",
+    "EiffelArtifactCreatedEvent",
+    "EiffelArtifactPublishedEvent",
+    "EiffelArtifactReusedEvent",
+    "EiffelTestCaseStartedEvent",
+    "EiffelTestCaseTriggeredEvent",
+    "EiffelTestCaseCanceledEvent",
+    "EiffelTestCaseFinishedEvent",
+    "EiffelTestSuiteStartedEvent",
+    "EiffelTestExecutionRecipeCollectionCreatedEvent",
+    "EiffelTestSuiteFinishedEvent",
+    "EiffelAnnouncementPublishedEvent",
+    "EiffelCompositionDefinedEvent",
+    "EiffelConfidenceLevelModifiedEvent",
+    "EiffelEnvironmentDefinedEvent",
+    "EiffelFlowContextDefinedEvent",
+    "EiffelIssueDefinedEvent",
+    "EiffelIssueVerifiedEvent",
+    "EiffelSourceChangeCreatedEvent",
+    "EiffelSourceChangeSubmittedEvent",
 ];
 
 #[derive(Parser)]

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -9,6 +9,7 @@ use eiffelvis_gen::{
     event_set::{Event, EventSet, Link},
     generator::EventGenerator,
 };
+
 use lapin::{options::*, BasicProperties, Connection, ConnectionProperties};
 
 use clap::Parser;
@@ -43,6 +44,7 @@ struct Cli {
     exchange: String,
 
     /// Routing key used for ampq connections
+
     #[clap(short, long)]
     routing_key: String,
 
@@ -89,14 +91,6 @@ async fn app() -> anyhow::Result<()> {
     .await?;
 
     let channel_a = conn.create_channel().await?;
-
-    channel_a
-        .queue_declare(
-            "hello",
-            QueueDeclareOptions::default(),
-            FieldTable::default(),
-        )
-        .await?;
 
     // println!(?queue, "Declared queue");
     println!("Connected to broker.");

--- a/backend/tools/event_sender/src/main.rs
+++ b/backend/tools/event_sender/src/main.rs
@@ -16,8 +16,11 @@ use clap::Parser;
 use rand::{thread_rng, Rng};
 
 const EVENT_TYPES: [&str; 23] = [
-    "ActC", "ActF", "ActS", "ActT", "AnnP", "ArtC", "ArtP", "ArtR", "TCC", "TCF", "TCS", "TCT",
-    "TERCC", "TSF", "TSS", "CD", "CLM", "ED", "FCD", "ID", "IV", "SCC", "SCS",
+    "EiffelActivityStartedEvent", "EiffelActivityTriggeredEvent", "EiffelActivityCanceledEvent", "EiffelActivityFinishedEvent", "EiffelArtifactCreatedEvent", 
+    "EiffelArtifactPublishedEvent", "EiffelArtifactReusedEvent", "EiffelTestCaseStartedEvent", "EiffelTestCaseTriggeredEvent", "EiffelTestCaseCanceledEvent", 
+    "EiffelTestCaseFinishedEvent", "EiffelTestSuiteStartedEvent", "EiffelTestExecutionRecipeCollectionCreatedEvent", "EiffelTestSuiteFinishedEvent", 
+    "EiffelAnnouncementPublishedEvent", "EiffelCompositionDefinedEvent", "EiffelConfidenceLevelModifiedEvent", "EiffelEnvironmentDefinedEvent", 
+    "EiffelFlowContextDefinedEvent", "EiffelIssueDefinedEvent", "EiffelIssueVerifiedEvent", "EiffelSourceChangeCreatedEvent", "EiffelSourceChangeSubmittedEvent",
 ];
 
 #[derive(Parser)]


### PR DESCRIPTION
origin ItJustWorksBetterTM/EiffelVis#22 with discussions

# Event Sender Modification 

## Description: 
  * Added Eiffel event list to the generator to allow for random event types
  * Added information on the README on how to connect event_sender / rabbitmq / backend
  * Changed the maximum amount of links per event to allow for a more realistic graph 
  * Added CLI arguments to allow for control over runtime and latency between events sent  
    * Arguments added: 

  | Argument name| Short name | Description | Default value|
  | ------------- | ------------- | ------------- | ------------- |
  | total_duration  | -t  | Total amount of time in milliseconds for the generator to run  |  3 600 000   |
  | min_latency  | -m  | Minimum value for the range of latency between events sent   |  5  |
  | latency_max  | -l  | Maximum value for the range of latency between events sent   |  220  |

## Useful notes:
* The default values of the CLI arguments (count, total_duration, min_latency and latency max ) are set to mimic roughly 30 000 events set per hour.
* The generator will run until either the count (total events to be sent) or the total_duration (duration for generator to run) has been reached.

## Screenshots:
Preview of random event types with random links:

![Screenshot 2022-10-14 195140](https://user-images.githubusercontent.com/81012809/195910189-e51a0d01-f8e1-4baf-a836-e6ec7d548350.png)

resolves #115 