### PR TITLE
Backend: use of partial keywords (wildcard) when filtering

### DIFF
--- a/backend/crates/eiffelvis_core/src/domain/user_queries.rs
+++ b/backend/crates/eiffelvis_core/src/domain/user_queries.rs
@@ -149,17 +149,18 @@ impl<I> TrackedQuery<I> {
                 true
             } else {
                 // Event filters itterator that returns nodes that contain the imput given (id filter has to be an exact match, all others do not.)
+                let data = node.data();
                 self.event_filters.iter().filter(|v| !v.is_empty()).any(|filters| {
                     filters.iter().all(|filter| match &filter.pred {
-                        EventFilter::Type { names: ref name } => name.iter().any(|name| node.data().meta.event_type.to_lowercase().contains(&name.to_lowercase())),
+                        EventFilter::Type { names: ref name } => name.iter().any(|name| data.meta.event_type.to_lowercase().contains(&name.to_lowercase())),
                         EventFilter::Id { ids } =>
                             ids.iter().any(|id| graph.get(*id).map(|n| n.id() == node.id()).unwrap_or(false)),
                         EventFilter::Tag { tags } =>
-                            tags.iter().any(|tag| node.data().meta.tags.as_ref().map(|v| v.contains(tag)).unwrap_or(false)),
+                            tags.iter().any(|tag| data.meta.tags.as_ref().map(|v| v.contains(tag)).unwrap_or(false)),
                         EventFilter::SourceHost { hosts } =>
-                            hosts.iter().any(|host|node.data().meta.source.as_ref().and_then(|s| s.host.as_ref()).map(|h| h.to_lowercase().contains(&host.to_lowercase())).unwrap_or(false)),
+                            hosts.iter().any(|host|data.meta.source.as_ref().and_then(|s| s.host.as_ref()).map(|h| h.to_lowercase().contains(&host.to_lowercase())).unwrap_or(false)),
                         EventFilter::SourceName { names } =>
-                            names.iter().any(|name| node.data().meta.source.as_ref().and_then(|s| s.name.as_ref()).map(|n| n.to_lowercase().contains(&name.to_lowercase())).unwrap_or(false)),
+                            names.iter().any(|name| data.meta.source.as_ref().and_then(|s| s.name.as_ref()).map(|n| n.to_lowercase().contains(&name.to_lowercase())).unwrap_or(false)),
                     } ^ filter.rev)
                 })
             }

--- a/backend/crates/eiffelvis_core/src/domain/user_queries.rs
+++ b/backend/crates/eiffelvis_core/src/domain/user_queries.rs
@@ -155,16 +155,16 @@ impl<I> TrackedQuery<I> {
                         EventFilter::Id { ids } =>
                             ids.iter().any(|id| graph.get(*id).map(|n| n.id() == node.id()).unwrap_or(false)),
                         EventFilter::Tag { tags } =>
-                            tags.iter().any(|tag| node.data().meta.tags.as_ref().map(|v| v.to_lowercase().contains(tag.to_lowercase())).unwrap_or(false)),
+                            tags.iter().any(|tag| node.data().meta.tags.as_ref().map(|v| v.contains(tag)).unwrap_or(false)),
                         EventFilter::SourceHost { hosts } =>
                             hosts.iter().any(|host|node.data().meta.source.as_ref().and_then(|s| s.host.as_ref()).map(|h| h.to_lowercase().contains(&host.to_lowercase())).unwrap_or(false)),
                         EventFilter::SourceName { names } =>
-                            names.iter().any(|name| node.data().meta.source.as_ref().and_then(|s| s.name.as_ref()).map(|n| n.to_lowercase().contains(name.to_lowercase())).unwrap_or(false)),
+                            names.iter().any(|name| node.data().meta.source.as_ref().and_then(|s| s.name.as_ref()).map(|n| n.to_lowercase().contains(&name.to_lowercase())).unwrap_or(false)),
                     } ^ filter.rev)
                 })
             }
         });
-        
+
         match self.collector {
             Collector::Forward => iter.map(|v| R::from(v.data())).collect(),
             Collector::SubGraph(ref mut sub) => {


### PR DESCRIPTION
# "Wildcard" / partial keyword filtering

originally ItJustWorksBetterTM/EiffelVis#43

## Description:
* Allows the user to filter (Type, SourceHost and SourceName) without having to enter the exact name.
* This is done using a combination of String::contains and String::To_lowercase. 
* The input and event attribute are both converted to lowercase in order allow for more flexibility when filtering.
* Avoided using regex due to the simple nature of these queries where string operations outperforms regex.

## Testing environment:
* Graph size of 4096 (4 times the default).
* Waited until the number of events reached the capacity of the graph.
* Had the generator running with the datadump while applying filters.
* Locally run

## Testing results:
* No visual performance decrease when applying filters.
* Filter results returned in an acceptable timeframe.
* No issues interacting with the graph when applying filters.