### PR TITLE
backend: allow client to somewhat control string matching

### DIFF
--- a/backend/crates/eiffelvis_core/src/domain/event_filter.rs
+++ b/backend/crates/eiffelvis_core/src/domain/event_filter.rs
@@ -1,0 +1,75 @@
+use crate::{domain::types::BaseEvent, graph::*};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventFilterMeta {
+    /// Reverses the predicate's result if true
+    #[serde(default)]
+    rev: bool,
+    pred: EventFilter,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum EventFilter {
+    /// Event Type
+    Type { names: Vec<String> },
+    /// Specific ids
+    Id { ids: Vec<Uuid> },
+    /// meta.tags
+    Tag { tags: Vec<String> },
+    /// meta.source.host
+    SourceHost { hosts: Vec<String> },
+    /// meta.source.name
+    SourceName { names: Vec<String> },
+}
+
+impl EventFilterMeta {
+    pub fn do_filter<'a, G, I>(&self, graph: &G, node: &NodeType<'a, G>) -> bool
+    where
+        G: Graph<Data = BaseEvent, Idx = I, Key = Uuid> + Indexable<usize>,
+        I: Idx,
+    {
+        let res = match &self.pred {
+            EventFilter::Type { names: ref name } => {
+                name.iter().any(|name| &node.data().meta.event_type == name)
+            }
+
+            EventFilter::Id { ids } => ids
+                .iter()
+                .any(|id| graph.get(*id).map(|n| n.id() == node.id()).unwrap_or(false)),
+
+            EventFilter::Tag { tags } => tags.iter().any(|tag| {
+                node.data()
+                    .meta
+                    .tags
+                    .as_ref()
+                    .map(|v| v.contains(tag))
+                    .unwrap_or(false)
+            }),
+
+            EventFilter::SourceHost { hosts } => hosts.iter().any(|host| {
+                node.data()
+                    .meta
+                    .source
+                    .as_ref()
+                    .and_then(|s| s.host.as_ref())
+                    .map(|h| h == host)
+                    .unwrap_or(false)
+            }),
+
+            EventFilter::SourceName { names } => names.iter().any(|name| {
+                node.data()
+                    .meta
+                    .source
+                    .as_ref()
+                    .and_then(|s| s.name.as_ref())
+                    .map(|n| n == name)
+                    .unwrap_or(false)
+            }),
+        };
+
+        res ^ self.rev
+    }
+}

--- a/backend/crates/eiffelvis_core/src/domain/mod.rs
+++ b/backend/crates/eiffelvis_core/src/domain/mod.rs
@@ -12,3 +12,6 @@ pub mod types;
 
 /// Query types and functions to acquire specific data from an [EiffelGraph]
 pub mod user_queries;
+
+/// Provides single node filtering.
+pub mod event_filter;

--- a/frontend/src/apidefinition.ts
+++ b/frontend/src/apidefinition.ts
@@ -17,20 +17,33 @@ export interface Event {
   edges: Array<Uuid>
 }
 
+export interface StringCompare {
+  lower_case: boolean,
+  partial: boolean,
+  value: string,
+}
+
+export const string_compare_eq = (lhs: StringCompare, rhs: StringCompare) =>
+  lhs.value == rhs.value &&
+  lhs.lower_case == rhs.lower_case &&
+  lhs.partial == rhs.partial
+
+export const string_compare_default = (): StringCompare => { return { value: "", lower_case: false, partial: false } }
+
 export type Type = TypeTag<'Type', {
-  names: string[]
+  names: StringCompare[]
 }>
 
 export type SourceHost = TypeTag<'SourceHost', {
-  hosts: string[]
+  hosts: StringCompare[]
 }>
 
 export type SourceName = TypeTag<'SourceName', {
-  names: string[]
+  names: StringCompare[]
 }>
 
 export type Tag = TypeTag<'Tag', {
-  tags: string[]
+  tags: StringCompare[]
 }>
 
 export type Id = TypeTag<'Id', {
@@ -41,13 +54,12 @@ export type EventFilterType = Type | Id | SourceHost | SourceName | Tag
 export const event_filter_type_eq = (lhs: EventFilterType, rhs: EventFilterType) =>
   lhs.type == rhs.type &&
   ((): boolean => {
-    const _rhs = rhs as any; // stupid linter...
     switch (lhs.type) {
-      case "Id": return lhs.ids.every((val) => _rhs.ids.includes(val))
-      case "SourceHost": return lhs.hosts.every((val) => _rhs.hosts.includes(val))
-      case "SourceName": return lhs.names.every((val) => _rhs.names.includes(val))
-      case "Tag": return lhs.tags.every((val) => _rhs.tags.includes(val))
-      case "Type": return lhs.names.every((val) => _rhs.names.includes(val))
+      case "Id": return lhs.ids.every((val) => (rhs as Id).ids.includes(val))
+      case "SourceHost": return lhs.hosts.every((val) => (rhs as SourceHost).hosts.every((rhs_val) => string_compare_eq(val, rhs_val)))
+      case "SourceName": return lhs.names.every((val) => (rhs as SourceName).names.every((rhs_val) => string_compare_eq(val, rhs_val)))
+      case "Tag": return lhs.tags.every((val) => (rhs as Tag).tags.every((rhs_val) => string_compare_eq(val, rhs_val)))
+      case "Type": return lhs.names.every((val) => (rhs as Type).names.every((rhs_val) => string_compare_eq(val, rhs_val)))
     }
   })()
 

--- a/frontend/src/components/FilterWidget.svelte
+++ b/frontend/src/components/FilterWidget.svelte
@@ -1,15 +1,17 @@
 <!-- svelte-ignore a11y-missing-attribute -->
 <script lang="ts">
-    import type {
+    import {
         EventFilter,
         Id,
         SourceHost,
         SourceName,
+        string_compare_default,
         Tag,
         Type,
     } from "../apidefinition";
 
     import LineInputList from "./LineInputList.svelte";
+    import Input from "./TextInput.svelte";
 
     const filter_types = ["Id", "Type", "Source", "Host", "Tag"];
     let active_filter = "Id";
@@ -44,7 +46,9 @@
                 bind:checked={ids.rev}
             />
         </label>
-        <LineInputList placeholder={"uuid"} bind:values={ids.pred.ids} />
+        <LineInputList bind:values={ids.pred.ids} let:index={i}>
+            <Input placeholder={"uuid"} bind:value={ids.pred.ids[i]}/>
+        </LineInputList>
         <button
             class="btn btn-xs w-full"
             on:click={() => (ids.pred.ids = [...ids.pred.ids, ""])}>+</button
@@ -63,13 +67,12 @@
                 bind:checked={types.rev}
             />
         </label>
-        <LineInputList
-            placeholder={"type name"}
-            bind:values={types.pred.names}
-        />
+        <LineInputList bind:values={types.pred.names} let:index={i}>
+            <Input placeholder={"type name"} bind:value={types.pred.names[i].value} />
+        </LineInputList>
         <button
             class="btn btn-xs w-full"
-            on:click={() => (types.pred.names = [...types.pred.names, ""])}
+            on:click={() => (types.pred.names = [...types.pred.names, string_compare_default()])}
             >+</button
         >
     </div>
@@ -86,14 +89,13 @@
                 bind:checked={sourcenames.rev}
             />
         </label>
-        <LineInputList
-            placeholder={"source name"}
-            bind:values={sourcenames.pred.names}
-        />
+        <LineInputList bind:values={sourcenames.pred.names} let:index={i}>
+            <Input placeholder={"source name"} bind:value={sourcenames.pred.names[i].value} />
+        </LineInputList>
         <button
             class="btn btn-xs w-full"
             on:click={() =>
-                (sourcenames.pred.names = [...sourcenames.pred.names, ""])}
+                (sourcenames.pred.names = [...sourcenames.pred.names, string_compare_default()])}
             >+</button
         >
     </div>
@@ -110,14 +112,13 @@
                 bind:checked={sourcehosts.rev}
             />
         </label>
-        <LineInputList
-            placeholder={"host name"}
-            bind:values={sourcehosts.pred.hosts}
-        />
+        <LineInputList values={sourcehosts.pred.hosts} let:index={i}>
+            <Input placeholder={"host name"} bind:value={sourcehosts.pred.hosts[i].value} />
+        </LineInputList>
         <button
             class="btn btn-xs w-full"
             on:click={() =>
-                (sourcehosts.pred.hosts = [...sourcehosts.pred.hosts, ""])}
+                (sourcehosts.pred.hosts = [...sourcehosts.pred.hosts, string_compare_default()])}
             >+</button
         >
     </div>
@@ -134,10 +135,12 @@
                 bind:checked={tags.rev}
             />
         </label>
-        <LineInputList placeholder={"tag name"} bind:values={tags.pred.tags} />
+        <LineInputList bind:values={tags.pred.tags} let:index={i}>
+            <Input placeholder={"tag name"} bind:value={tags.pred.tags[i].value} />
+        </LineInputList>
         <button
             class="btn btn-xs w-full"
-            on:click={() => (tags.pred.tags = [...tags.pred.tags, ""])}
+            on:click={() => (tags.pred.tags = [...tags.pred.tags, string_compare_default()])}
             >+</button
         >
     </div>

--- a/frontend/src/components/LineInputList.svelte
+++ b/frontend/src/components/LineInputList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+
     export let values;
-    export let placeholder;
 </script>
 
 <div class="form-control">
@@ -27,12 +27,7 @@
                     />
                 </svg>
             </button>
-            <input
-                type="text"
-                {placeholder}
-                bind:value
-                class="input input-sm input-bordered basis-full"
-            />
+            <slot index={i}></slot>
         </div>
     {/each}
 </div>

--- a/frontend/src/components/TextInput.svelte
+++ b/frontend/src/components/TextInput.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+    export let value: string;
+    export let placeholder: string;
+</script>
+
+<input
+    type="text"
+    placeholder={placeholder}
+    bind:value={value}
+    class="input input-sm input-bordered basis-full"
+/>


### PR DESCRIPTION
commit 1:
rustfmt failed to format anything before, and this moves out some complexity.

As a bonus. this removes a repeated branch for when there are no filters, so minor speed up?

commit 2:
adds lower_case and partial options for string searches in query filters.