### PR TITLE
backend-builder: sha1 not found

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,3 +16,4 @@ serde_json = { version = "1.0" }
 clap = { version="3.2.5", features=["derive"]}
 tracing = "0.1"
 tracing-subscriber = "0.3"
+sha1 = "0.10.5"


### PR DESCRIPTION
When trying to build the project using Docker the backend-builder at step 5 fails. `RUN cargo install --root ./dist/ --path . `

I noticed that there is an unresolved import called sha1.
```
#0 330.7 error[E0432]: unresolved import `sha1`
#0 330.7   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/tungstenite-0.17.3/src/handshake/mod.rs:15:5
#0 330.7    |
#0 330.7 15 | use sha1::{Digest, Sha1};
#0 330.7    |     ^^^^ use of undeclared crate or module `sha1`
#0 330.7    |
#0 330.7 help: there is a crate or module with a similar name
#0 330.7    |
#0 330.7 15 | use sha_1::{Digest, Sha1};
#0 330.7    |     ~~~~~
#0 330.7 
#0 331.1 For more information about this error, try `rustc --explain E0432`.
#0 331.1 error: could not compile `tungstenite` due to previous error
#0 331.1 warning: build failed, waiting for other jobs to finish...
#0 336.9 error: failed to compile `eiffelvis v0.1.0 (/opt/EiffelVis)`, intermediate artifacts can be found at `/opt/EiffelVis/target`
------
failed to solve: executor failed running [/bin/sh -c cargo install --root ./dist/ --path .]: exit code: 101

 ```

I added this dependency to Cargo.toml and now Docker can build the project.