### PR TITLE
Frontend: Hide filter panel when toggled off

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -27,7 +27,9 @@
   let show_menu: boolean = false;
   let show_legend: boolean = true;
   let show_timebar: boolean = false;
+  let show_filter_panel: boolean = false; 
   $: nonInteractiveState = true
+
 
   let customTheme: Object = config.Theme.ColorBlind;
   let themeMap: Map<string, any> = new Map(Object.entries(customTheme));
@@ -227,6 +229,11 @@ const displayInfoMessage= () =>{ //After 1 minute of no nodes recieved, a messag
     show_legend = !show_legend;
   };
 
+  const toggleFilterPanel = () => {
+    show_filter_panel = !show_filter_panel;
+  };
+  
+
   //Updates the timebar each time the show timebar button is clicked
   const updateTimebar = () =>{  
             (show_timebar = !show_timebar),
@@ -285,8 +292,10 @@ const displayInfoMessage= () =>{ //After 1 minute of no nodes recieved, a messag
     show_legend = {show_legend}
     show_menu = {show_menu} 
     interactiveMode = {nonInteractiveState}
+    show_filter_panel = {show_filter_panel}
     toggleMenuPlaceholder = {toggleMenu} 
     toggleLegendPlaceholder = {toggleLegend} 
+    toggleFilterPanelPlaceholder = {toggleFilterPanel}
     updateTimeBarPlaceholder = {updateTimebar}
     toggleInteractiveModePlaceholder = {toggleInteractiveMode}
 
@@ -295,6 +304,7 @@ const displayInfoMessage= () =>{ //After 1 minute of no nodes recieved, a messag
         style="z-index:1"
       >   <!-- panels  -->
       <Panel 
+        show_filter_panel = {show_filter_panel}
         show_legend_placeholder = {show_legend} 
         show_menu_placeholder = {show_menu} 
         reset_graph_options_placeholder = {reset_graph_options}

--- a/frontend/src/components/Panel.svelte
+++ b/frontend/src/components/Panel.svelte
@@ -12,6 +12,7 @@
     export let show_menu_placeholder: boolean; 
     export let awaiting_query_request: boolean; 
     export let current_query_changed: boolean; 
+    export let show_filter_panel: boolean;
 
     $: current_query_changed =
     qhistory.length > 0 &&
@@ -58,9 +59,10 @@
         </li>
         <li>
             <div
-              class="p-3 bg-base-200 shadow-md h-fit bottom-0 fixed w-fit m-0 rounded-r-lg" 
+              class="overflow-x-auto overflow-y-auto bottom-0 bg-base-200  fixed shadow-md h-fit fixed w-0 m-0 rounded-r-lg" 
+              class:show={show_filter_panel}
             >
-              <div class="container h-full w-full p-1 overflow-hidden scroll-auto">
+              <div class="container h-full w-full p-3 overflow-hidden scroll-auto">
                 <div class:hidden={!selected_node} class="rounded-box bg-accent p-3 mb-2">
                   <EventDetail {selected_node} on:useroot={use_selected_as_root} />
                 </div>

--- a/frontend/src/components/SideBar.svelte
+++ b/frontend/src/components/SideBar.svelte
@@ -5,11 +5,13 @@
    export let show_legend: boolean;
    export let show_timebar: boolean;
    export let interactiveMode: boolean;
+   export let show_filter_panel: boolean;
 
    export let updateTimeBarPlaceholder: () => void; //it was called directly inside the div element, now: a method is created inside app.svelt
    export let toggleMenuPlaceholder: () => void;  
    export let toggleLegendPlaceholder: () => void;
    export let toggleInteractiveModePlaceholder: () => void;
+   export let toggleFilterPanelPlaceholder: () => void;
 
 </script>
 <div class="flex h-screen w-16">
@@ -33,6 +35,13 @@
             btnState= {show_legend} 
             data = "M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268
                      2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+        />
+      </li>
+      <li>
+        <SvgButton 
+            onClickAction= {toggleFilterPanelPlaceholder} 
+            btnState= {show_filter_panel} 
+            data="M3, 11 a 8,8 0 1,0 16, 0 a 8,8 0 1, 0 -16, 0  M 21 21 16.65 16.65"
         />
       </li>
       <li> 


### PR DESCRIPTION
# Add a filter button and hide the filter panel when toggled off 

## Description

* Add a filter button 
* Add the styles and methods needed to toggle on/off the panel

## Screenshot

<img width="509" alt="Screenshot 2022-12-12 at 12 37 24" src="https://user-images.githubusercontent.com/75277107/207038472-b2104fd2-c6da-4a37-b3fe-78b1acd1e3f7.png">

## Testing 
* I tested the filter and the button functionality.

closes #33


