### PR TITLE
Fix: filter overflow

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -353,7 +353,7 @@ const displayInfoMessage= () =>{ //After 1 minute of no nodes recieved, a messag
   @tailwind components;
   @tailwind utilities;
   .show {
-    width: 320px;
+    width: 375px;
   }
   .move {
     margin-right: 350px;

--- a/frontend/src/components/ColorLegend.svelte
+++ b/frontend/src/components/ColorLegend.svelte
@@ -6,8 +6,8 @@
     import { defaultNode } from "../layout";
     const options = {
         container: "mountNode",
-        width: 280,
-        height: 220,
+        width: 335,
+        height: 210,
         workerEnabled: true,
         nodeSize: 20,
     };

--- a/frontend/src/components/Panel.svelte
+++ b/frontend/src/components/Panel.svelte
@@ -40,7 +40,7 @@
             <ColorLegend {styles} />
           </div>       
             <div
-              class="mt-auto pointer-events-auto bg-base-200 shadow-md rounded-r-lg overflow-y-scroll" 
+              class="mt-auto pointer-events-auto bg-base-200 shadow-md rounded-r-lg overflow-y-auto" 
               class:show={show_filter_panel}
               class:hidden={!show_filter_panel}
             >

--- a/frontend/src/components/Panel.svelte
+++ b/frontend/src/components/Panel.svelte
@@ -40,7 +40,7 @@
             <ColorLegend {styles} />
           </div>       
             <div
-              class="mt-auto pointer-events-auto bg-base-200 shadow-md rounded-r-lg" 
+              class="mt-auto pointer-events-auto bg-base-200 shadow-md rounded-r-lg overflow-y-scroll" 
               class:show={show_filter_panel}
               class:hidden={!show_filter_panel}
             >


### PR DESCRIPTION
Bug fix for https://github.com/ItJustWorksBetterTM/EiffelVis/issues/62
Original PR: https://github.com/ItJustWorksBetterTM/EiffelVis/pull/63
# Summary: 
When the filter panel is getting too big to be contained in the screen (by expanding the filters list) the scroll happens on the app level displacing all elements.

# Solution:
- When overflowing, the filter will be scrollable without displacing the all app
- Made the legend and filter panel a bit larger to avoid `tag` to go on a new line


![](https://user-images.githubusercontent.com/71485862/210237644-e28191e9-6cab-48e4-a960-93e4022ed929.png)
