### PR TITLE
formatting fix for all svelte files

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -4,5 +4,6 @@
     "tabWidth": 4,
     "trailingComma": "all",
     "quoteProps": "as-needed",
-    "singleQuote": true
+    "singleQuote": true,
+    "plugins": ["svelte"]
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,6 @@
         "postcss": "^8.4.4",
         "postcss-loader": "^6.2.1",
         "precss": "^4.0.0",
-        "prettier": "^2.8.1",
         "style-loader": "^3.3.1",
         "tailwindcss": "^3.0.12"
       },
@@ -25,6 +24,8 @@
         "cross-env": "^7.0.3",
         "css-loader": "^5.2.7",
         "mini-css-extract-plugin": "^1.3.4",
+        "prettier": "^2.8.2",
+        "prettier-plugin-svelte": "^2.9.0",
         "svelte": "^3.49.0",
         "svelte-check": "^1.0.46",
         "svelte-loader": "^3.0.0",
@@ -5769,9 +5770,10 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
+      "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
+      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -5780,6 +5782,16 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-svelte": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.9.0.tgz",
+      "integrity": "sha512-3doBi5NO4IVgaNPtwewvrgPpqAcvNv0NwJNflr76PIGgi9nf1oguQV1Hpdm9TI2ALIQVn/9iIwLpBO5UcD2Jiw==",
+      "dev": true,
+      "peerDependencies": {
+        "prettier": "^1.16.4 || ^2.0.0",
+        "svelte": "^3.2.0"
       }
     },
     "node_modules/probe.gl": {
@@ -11935,9 +11947,17 @@
       }
     },
     "prettier": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg=="
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
+      "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
+      "dev": true
+    },
+    "prettier-plugin-svelte": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.9.0.tgz",
+      "integrity": "sha512-3doBi5NO4IVgaNPtwewvrgPpqAcvNv0NwJNflr76PIGgi9nf1oguQV1Hpdm9TI2ALIQVn/9iIwLpBO5UcD2Jiw==",
+      "dev": true,
+      "requires": {}
     },
     "probe.gl": {
       "version": "3.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,8 @@
     "cross-env": "^7.0.3",
     "css-loader": "^5.2.7",
     "mini-css-extract-plugin": "^1.3.4",
+    "prettier": "^2.8.2",
+    "prettier-plugin-svelte": "^2.9.0",
     "svelte": "^3.49.0",
     "svelte-check": "^1.0.46",
     "svelte-loader": "^3.0.0",
@@ -22,7 +24,7 @@
     "build": "cross-env NODE_ENV=production webpack",
     "dev": "webpack serve --static-directory public",
     "validate": "svelte-check",
-    "format": "prettier . --write"
+    "format": "prettier . --write ./**/*.svelte"
   },
   "dependencies": {
     "@antv/g6": "^4.5.1",
@@ -32,7 +34,6 @@
     "postcss": "^8.4.4",
     "postcss-loader": "^6.2.1",
     "precss": "^4.0.0",
-    "prettier": "^2.8.1",
     "style-loader": "^3.3.1",
     "tailwindcss": "^3.0.12"
   }


### PR DESCRIPTION
Overlooked svelte files with prettier formatting, this is a fix to make sure that we iterate over all .svelte files with npm run format.